### PR TITLE
Change Exporter export() parameters to object

### DIFF
--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -28,8 +28,8 @@ export function loadExporter() {
 				settingId: 'snavesutit:unnamed_exporter/foo',
 			},
 		],
-		async export(ajSettings, projectSettings, exporterSettings) {
-			console.log(ajSettings, projectSettings, exporterSettings)
+		async export({ajSettings, projectSettings, exporterSettings}) {
+			console.log({ajSettings, projectSettings, exporterSettings})
 			await new Promise(resolve => setTimeout(resolve, 100))
 		},
 	})


### PR DESCRIPTION
Very simple bug fix with the Exporter export() function to specify an object as the parameter.